### PR TITLE
Lab 6 - Update CustomersCardComponent constructor

### DIFF
--- a/Labs/Component Properties and Angular Directives/Files/BeginFiles/src/app/customers/customers-card.component.ts
+++ b/Labs/Component Properties and Angular Directives/Files/BeginFiles/src/app/customers/customers-card.component.ts
@@ -38,7 +38,7 @@ export class CustomersCardComponent implements OnInit {
 
 
   
-  constructor(private trackbyService: TrackByService) { }
+  constructor(public trackbyService: TrackByService) { }
   
   ngOnInit() {
 


### PR DESCRIPTION
To make TrackByService public so that customers-card.component.html can see it when being used in the `*ngFor`

The [final code](https://github.com/DanWahlin/Angular-JumpStart/blob/master/src/app/customers/customers-card.component.ts#L34) has this as `public` as well.

This issue was pointed out by VSCode while updating customers-card.component.html. This was made possible by the [Angular Language Service extension](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).